### PR TITLE
use /bin/bash instead of default /bin/sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ else
 Q =
 endif
 
+ifeq ("$(SHELL)", "/bin/sh")
+SHELL=/bin/bash
+endif
+
 KICAD_CLI ?= kicad-cli
 PDFUNITE ?= pdfunite
 PCB_HELPER ?= ./scripts/pcb_helper.py


### PR DESCRIPTION
The command `let` is not available in `/bin/sh`. If make tries to use the default `/bin/sh`, set SHELL to `/bin/bash`.

If the shell is already set to something else, that seems deliberate, so SHELL is not changed.

(fixes #1 `/bin/sh: 9: let: not found`)